### PR TITLE
Add z-index to observatory panel

### DIFF
--- a/client/observatory.less
+++ b/client/observatory.less
@@ -130,6 +130,7 @@ tr.no_border,
 	padding: 10px 10px 10px 40px;
 	filter: alpha(opacity=85);
 	opacity: .85;
+	z-index: 100000;
 }
 
 .observatory_panel a, .observatory_panel a:visited{


### PR DESCRIPTION
Hi,

Thanks for your work on this.  It's a pretty slick logger.

I have one small improvement here.  When the underlying page has an element that uses a z-index, that element will appear on top of the logging panel.  I've added a large z-index to the observatory panel css so that it will be remain on top.

Thanks,
Jason
